### PR TITLE
Use key "username" (not "user") for loginWithUsername

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -92,7 +92,7 @@ attemptLogin = (ddp, user, pass, options, cb) ->
       return cb err, res
 
 loginWithUsername = (ddp, username, password, options..., cb) ->
-   attemptLogin ddp, {user: username}, password, options[0], cb
+   attemptLogin ddp, {username: username}, password, options[0], cb
 
 loginWithEmail = (ddp, email, password, options..., cb) ->
    attemptLogin ddp, {email: email}, password, options[0], cb


### PR DESCRIPTION
When trying to login with the above function, I get (in Meteor 0.8.3):

``` js
{ error: 400,
  reason: 'Match failed',
  message: 'Match failed [400]',
  errorType: 'Meteor.Error' }
```

correcting the above fixes the problem, not sure if this changed in Meteor recently.
